### PR TITLE
visually changes the side bar

### DIFF
--- a/src/app/user/achievements/achievements.component.html
+++ b/src/app/user/achievements/achievements.component.html
@@ -12,8 +12,8 @@
   <div class="row">
     <div class="col-sm-12">
       <h6 class="lead">
-        Earn entries by completing achievements.
-        <br> Each entry increases your chance of being awarded a prize at the end of the day!
+        Get achievements to increase your chances of winning the daily prizes.
+        <br> If you found a secret QR code, <a routerLink="/user/redeem">scan it</a> to unlock a hidden achievement!
       </h6>
     </div>
   </div>

--- a/src/app/user/link/my-links/my-links.component.css
+++ b/src/app/user/link/my-links/my-links.component.css
@@ -205,3 +205,8 @@ img.portrait {
 .black-text {
   color: black;
 }
+
+h6.lead{
+  margin-bottom: 40px;
+  text-align: center;
+}

--- a/src/app/user/link/my-links/my-links.component.html
+++ b/src/app/user/link/my-links/my-links.component.html
@@ -30,11 +30,13 @@
     </div>
   </div>
 
-  <div *ngIf="!processedLinks?.length" class="row">
+  <div class="row">
     <div class="col-sm-12">
-      <h6 class="lead">
+      <h6 *ngIf="!processedLinks?.length" class="lead">
         Looks like you have not made any links yet.
-        <br> You can link with {{me.role === "company" ? "attendees" : "companies"}}
+      </h6>
+      <h6 class="lead">
+        You can link with {{me.role === "company" ? "attendees" : "companies"}}
         <a routerLink="/user/links/link">here</a>.
       </h6>
     </div>

--- a/src/app/user/user.component.css
+++ b/src/app/user/user.component.css
@@ -132,6 +132,7 @@
   display: flex;
   flex-direction: column;
   justify-content: end;
+  padding-bottom: 3dvh;
 }
 
 .fab {
@@ -170,4 +171,8 @@
   justify-content: space-between;
   width: 100%;
   height: 100%;
+}
+
+.navlist {
+  height: -webkit-fill-available !important;
 }

--- a/src/app/user/user.component.html
+++ b/src/app/user/user.component.html
@@ -48,12 +48,12 @@
           <span class="list-item">QR Code</span>
         </div>
       </a>
-      <a *ngIf="user && user.role !== 'company'" mat-list-item routerLink="/user/cv"
+      <h2 *ngIf="user && user.role === 'team'" matSubheader style="color: grey;">Staff Options</h2>
+      <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/promote"
         routerLinkActive="navigation-link active" (click)="sidenav.toggle()" class="mat-list-item-custom">
         <div class="navigation-link">
-          <mat-icon *ngIf="!isCvUpdated" matBadge="!" matBadgeColor="warn" matBadgeSize="small">account_box</mat-icon>
-          <mat-icon *ngIf="isCvUpdated">account_box</mat-icon>
-          <span class="list-item">Upload CV</span>
+          <mat-icon>verified_user</mat-icon>
+          <span class="list-item">Promote</span>
         </div>
       </a>
       <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/checkin"
@@ -70,15 +70,39 @@
           <span class="list-item">Validate Card</span>
         </div>
       </a>
-      <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/promote"
-        routerLinkActive="navigation-link active" (click)="sidenav.toggle()" class="mat-list-item-custom">
-        <div class="navigation-link">
-          <mat-icon>verified_user</mat-icon>
-          <span class="list-item">Promote</span>
-        </div>
-      </a>
+      <mat-accordion *ngIf="user && user.role === 'team'">
+        <mat-expansion-panel style="background-color: transparent !important">
+          <mat-expansion-panel-header class="specific-class">
+            <a mat-list-item>
+              <div class="navigation-link">
+                <mat-icon>cake</mat-icon>
+                <span class="list-item">Pick Winner</span>
+                <mat-icon>keyboard_arrow_right</mat-icon>
+              </div>
+            </a>
+          </mat-expansion-panel-header>
+          <mat-nav-list>
+            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/prizes"
+              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
+              <div class="navigation-link">
+                <mat-icon>cake</mat-icon>
+                <span class="list-item">Prizes</span>
+              </div>
+            </a>
+            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/pick-winner"
+              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
+              <div class="navigation-link">
+                <mat-icon>cake</mat-icon>
+                <span class="list-item">Pick Winner</span>
+              </div>
+            </a>
+          </mat-nav-list>
+        </mat-expansion-panel>
+      </mat-accordion>
+      
+      <h2 *ngIf="user && user.role === 'team'" matSubheader style="color: grey;">Company Options</h2>
       <a
-        *ngIf="user"
+        *ngIf="user && user.role === 'company'"
         mat-list-item
         routerLink="/user/links/link"
         routerLinkActive="navigation-link active"
@@ -87,11 +111,82 @@
       >
         <div class="navigation-link">
           <mat-icon>done_outline</mat-icon>
-          <span class="list-item">{{(user.role === 'company' ? "Sign and ": "" )}}Link Card </span>
+          <span class="list-item">Sign and Link Card </span>
         </div>
       </a>
       <a
-        *ngIf="user"
+        *ngIf="user && user.role !== 'user'"
+        mat-list-item
+        routerLink="/user/links/my-links"
+        routerLinkActive="navigation-link active"
+        (click)="sidenav.toggle()"
+        class="navigation-link"
+      >
+        <div class="navigation-link">
+          <mat-icon> forum</mat-icon>
+          <span class="list-item">My links</span>
+        </div>
+      </a>
+      <a *ngIf="user && user.role === 'company'" mat-list-item routerLink="/user/downloads/download"
+        routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
+        <div class="navigation-link">
+          <mat-icon>get_app</mat-icon>
+          <span class="list-item">Download CVs</span>
+        </div>
+      </a>
+      
+      <mat-accordion *ngIf="user && user.role === 'team'">
+        <mat-expansion-panel style="background-color: transparent !important">
+          <mat-expansion-panel-header class="specific-class">
+            <a mat-list-item class="navigation-link">
+              <div class="navigation-link">
+                <mat-icon>get_app</mat-icon>
+                <span class="list-item">CV Downloads </span>
+                <mat-icon>keyboard_arrow_right</mat-icon>
+              </div>
+            </a>
+          </mat-expansion-panel-header>
+          <mat-nav-list>
+            <a *ngIf="user && user.role !== 'user'" mat-list-item routerLink="/user/downloads/download"
+              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
+              <div class="navigation-link">
+                <mat-icon>get_app</mat-icon>
+                <span class="list-item">Download CVs</span>
+              </div>
+            </a>
+            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/downloads/manage"
+              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
+              <div class="navigation-link">
+                <mat-icon>get_app</mat-icon>
+                <span class="list-item">Create Endpoints</span>
+              </div>
+            </a>
+            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/downloads/status"
+              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
+              <div class="navigation-link">
+                <mat-icon>get_app</mat-icon>
+                <span class="list-item">Endpoints Status</span>
+              </div>
+            </a>
+          </mat-nav-list>
+        </mat-expansion-panel>
+      </mat-accordion>
+    
+      <h2 *ngIf="user && user.role === 'team'" matSubheader style="color: grey;">Atendee Options</h2>
+
+      <a *ngIf="user && user.role !== 'company'" mat-list-item routerLink="/user/cv"
+        routerLinkActive="navigation-link active" (click)="sidenav.toggle()" class="mat-list-item-custom">
+        <div class="navigation-link">
+          <mat-icon *ngIf="!isCvUpdated" matBadge="!" matBadgeColor="warn" matBadgeSize="small">account_box</mat-icon>
+          <mat-icon *ngIf="isCvUpdated">account_box</mat-icon>
+          <span class="list-item">Upload CV</span>
+        </div>
+      </a>  
+
+      <!-- Ugly fix one day before the event. Just to have the 'Upload CV' on the top for users
+      and on the 'Attendee options' section for members -->
+      <a
+        *ngIf="user && user.role === 'user'"
         mat-list-item
         routerLink="/user/links/my-links"
         routerLinkActive="navigation-link active"
@@ -148,79 +243,10 @@
               </div>
             </a>
           </mat-nav-list>
-        </mat-expansion-panel>
-
-        <mat-expansion-panel style="background-color: transparent !important">
-          <mat-expansion-panel-header class="specific-class">
-            <a mat-list-item>
-              <div class="navigation-link">
-                <mat-icon>cake</mat-icon>
-                <span class="list-item">Pick Winner</span>
-                <mat-icon>keyboard_arrow_right</mat-icon>
-              </div>
-            </a>
-          </mat-expansion-panel-header>
-          <mat-nav-list>
-            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/prizes"
-              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
-              <div class="navigation-link">
-                <mat-icon>cake</mat-icon>
-                <span class="list-item">Prizes</span>
-              </div>
-            </a>
-            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/pick-winner"
-              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
-              <div class="navigation-link">
-                <mat-icon>cake</mat-icon>
-                <span class="list-item">Pick Winner</span>
-              </div>
-            </a>
-          </mat-nav-list>
-        </mat-expansion-panel>
-
-        <mat-expansion-panel style="background-color: transparent !important">
-          <mat-expansion-panel-header class="specific-class">
-            <a mat-list-item class="navigation-link">
-              <div class="navigation-link">
-                <mat-icon>get_app</mat-icon>
-                <span class="list-item">CV Downloads </span>
-                <mat-icon>keyboard_arrow_right</mat-icon>
-              </div>
-            </a>
-          </mat-expansion-panel-header>
-          <mat-nav-list>
-            <a *ngIf="user && user.role !== 'user'" mat-list-item routerLink="/user/downloads/download"
-              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
-              <div class="navigation-link">
-                <mat-icon>get_app</mat-icon>
-                <span class="list-item">Download CVs</span>
-              </div>
-            </a>
-            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/downloads/manage"
-              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
-              <div class="navigation-link">
-                <mat-icon>get_app</mat-icon>
-                <span class="list-item">Create Endpoints</span>
-              </div>
-            </a>
-            <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/downloads/status"
-              routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
-              <div class="navigation-link">
-                <mat-icon>get_app</mat-icon>
-                <span class="list-item">Endpoints Status</span>
-              </div>
-            </a>
-          </mat-nav-list>
-        </mat-expansion-panel>
+        </mat-expansion-panel>  
       </mat-accordion>
 
-      <a *ngIf="user && user.role === 'company'" mat-list-item routerLink="/user/downloads/download"
-        routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
-        <div class="navigation-link">
-          <mat-icon>get_app</mat-icon>
-          <span class="list-item">Download CVs</span>
-        </div>
-      </a>
+      
 
       <a *ngIf="user && user.role !== 'company'" mat-list-item routerLink="/user/achievements"
         routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
@@ -241,27 +267,28 @@
         <mat-icon>stars</mat-icon>
         <span class="list-item">Secret Codes</span>
       </a> -->
-      <a *ngIf="user && user.role !== 'company'" mat-list-item routerLink="/user/redeem"
+      <!-- <a *ngIf="user && user.role !== 'company'" mat-list-item routerLink="/user/redeem"
         routerLinkActive="navigation-link active" (click)="sidenav.toggle()">
         <div class="navigation-link">
           <mat-icon>stars</mat-icon>
           <span class="list-item">Redeem Achievement</span>
         </div>
-      </a>
+      </a> -->
+      <!-- create a space between -->
       <a *ngIf="user" mat-list-item routerLink="/user/promocodes" routerLinkActive="navigation-link active"
-        (click)="sidenav.toggle()" class="navigation-link">
+        (click)="sidenav.toggle()" class="mat-list-item-custom">
         <div class="navigation-link">
           <mat-icon>receipt</mat-icon>
           <span class="list-item">Promo Codes</span>
         </div>
       </a>
-      <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/add-achievement"
+      <!-- <a *ngIf="user && user.role === 'team'" mat-list-item routerLink="/user/add-achievement"
         routerLinkActive="navigation-link active" (click)="sidenav.toggle()" class="mat-list-item-custom">
         <div class="navigation-link">
           <mat-icon>star_border</mat-icon>
           <span class="list-item">Add achievement</span>
         </div>
-      </a>
+      </a> -->
       <div class="gap"></div>
       <div class="bottom">
         <a *ngIf="isLoggedIn" mat-list-item (click)="sidenav.toggle()"


### PR DESCRIPTION
Removes 2 options from the side bar: "Redeem Achievement"  and "Link Card". 

"Redeem Achievement", which only function is to redeem secrete achievements is combined with "Achievements"
"Link Card" is combined in "My Links"

Also, some options are pushed to the bottom of the page and some subsections are added to the member's view only. As seen in the pictures below

![atendeeView](https://github.com/sinfo/ng-sinfo-webapp/assets/75808145/3886e5a7-b1e1-4988-b217-ba4c60da3677)
![companyView](https://github.com/sinfo/ng-sinfo-webapp/assets/75808145/24f62137-9b33-4883-9da6-ba5b40d4067f)
![memberView](https://github.com/sinfo/ng-sinfo-webapp/assets/75808145/55a305d2-3a76-4308-8b7d-447f7b924cb3)
