### PR TITLE
fix: change indigo-pink css theme

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,7 @@
   <link rel="stylesheet" type="text/css"
     href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-  <link href="https://unpkg.com/@angular/material/prebuilt-themes/indigo-pink.css" rel="stylesheet" />
+  <link href="https://unpkg.com/@angular/material@15.1.4/prebuilt-themes/indigo-pink.css" rel="stylesheet" />
   <link href='https://fonts.googleapis.com/css?family=Montserrat' rel='stylesheet'>
 
 


### PR DESCRIPTION
Lock the pre-built theme to the currently used package version.

In the future, this should point to the the installed node_module.